### PR TITLE
Use `InputStream` to read resources

### DIFF
--- a/src/main/resources/io/jenkins/plugins/autify/AutifyCli/install.sh
+++ b/src/main/resources/io/jenkins/plugins/autify/AutifyCli/install.sh
@@ -1,6 +1,6 @@
 URL="https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"
 if [ $(command -v curl) ]; then
-  curl "$URL" | bash
+  curl "$URL" | bash -xe
 else
-  wget -O- "$URL" | bash
+  wget -O- "$URL" | bash -xe
 fi


### PR DESCRIPTION
Since the resource path inside the jar file is not a valid file path, Jenkins can't read the resources.

This commit changes to use `InputStream` so that Jenkins can read the content from the jar file.

<!-- Please describe your pull request here. -->

Close #5 

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
