### PR TITLE
Execute install script from URL directly

### DIFF
--- a/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
+++ b/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.autify;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintStream;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class AutifyCli {
     }
 
     public int install() {
-        return runShellScript("AutifyCli/install.sh");
+        return runShellScript("https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash");
     }
 
     public int webTestRun(String autifyUrl, boolean wait) {
@@ -86,20 +87,18 @@ public class AutifyCli {
         return envs;
     }
 
-    protected int runShellScript(String scriptName) {
-        InputStream scriptStream = getClass().getResourceAsStream(scriptName);
-        if (scriptStream == null) {
-            logger.println("Cannot find the script '" + scriptName + "'");
-            return 1;
-        }
-        int ret = runCommand(scriptStream, "bash", "-xe");
+    protected int runShellScript(String scriptUrl) {
         try {
+            URL url = new URL(scriptUrl);
+            InputStream scriptStream = url.openStream();
+            logger.println("Executing script from " + scriptUrl);
+            int ret = runCommand(scriptStream, "bash", "-xe");
             scriptStream.close();
+            return ret;
         } catch (IOException e) {
             e.printStackTrace(logger);
             return 1;
         }
-        return ret;
     }
 
     public static class Factory {

--- a/src/main/resources/io/jenkins/plugins/autify/AutifyCli/install.sh
+++ b/src/main/resources/io/jenkins/plugins/autify/AutifyCli/install.sh
@@ -1,6 +1,0 @@
-URL="https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash"
-if [ $(command -v curl) ]; then
-  curl "$URL" | bash -xe
-else
-  wget -O- "$URL" | bash -xe
-fi


### PR DESCRIPTION
We realized that the `AutifyCli/install.sh` is no more needed.

This commit changes to read the install script from URL directly via `InputStream`.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
