### PR TITLE
Fix `index.jelly`

### DIFF
--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Plugin to run a test on Autify for Web
+    Plugin to run a test on <a href="https://autify.com" rel="noopener noreferrer">Autify</a>.
 </div>


### PR DESCRIPTION
Since this plugin is intended not only for Autify for Web but also Autify for Mobile,
we should fix `index.jelly` which is used by Plugin Manager.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
