### PR TITLE
Apply `@DataBoundSetter` to all fields

### DIFF
--- a/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
+++ b/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
@@ -8,15 +8,18 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
+
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Launcher.ProcStarter;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
-import io.jenkins.cli.shaded.org.apache.commons.lang.StringUtils;
 import io.jenkins.plugins.autify.model.UrlReplacement;
 
 public class AutifyCli {
+
+    public static final String INSTALL_SCRIPT_URL = "https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash";
 
     protected final FilePath workspace;
     protected final Launcher launcher;
@@ -32,7 +35,7 @@ public class AutifyCli {
     }
 
     public int install() {
-        return runShellScript("https://autify-cli-assets.s3.amazonaws.com/autify-cli/channels/stable/install-cicd.bash");
+        return runShellScript(INSTALL_SCRIPT_URL);
     }
 
     public int webTestRun(String autifyUrl, boolean wait, String timeout, List<UrlReplacement> urlReplacements, String testExecutionName, String browser, String device, String deviceType, String os, String osVersion) {
@@ -118,8 +121,7 @@ public class AutifyCli {
         }
 
         public Builder addFlag(String flag, String value) {
-            value = StringUtils.trimToNull(value);
-            if (value != null) add(flag, value);
+            if (StringUtils.isNotBlank(value)) add(flag, value);
             return this;
         }
 

--- a/src/main/java/io/jenkins/plugins/autify/AutifyWebBuilder.java
+++ b/src/main/java/io/jenkins/plugins/autify/AutifyWebBuilder.java
@@ -86,10 +86,11 @@ public class AutifyWebBuilder extends Builder implements SimpleBuildStep {
     }
 
     public String getTimeout() {
-        return StringUtils.isEmpty(timeout) ? null : timeout;
+        return StringUtils.trimToEmpty(timeout);
     }
 
-    public void setTimeout(final String value) {
+    @DataBoundSetter
+    public void setTimeout(@CheckForNull String value) {
         this.timeout = value;
     }
 
@@ -97,55 +98,62 @@ public class AutifyWebBuilder extends Builder implements SimpleBuildStep {
         return urlReplacements == null ? Collections.emptyList() : urlReplacements;
     }
 
+    @DataBoundSetter
     public void setUrlReplacements(@CheckForNull List<UrlReplacement> value) {
         this.urlReplacements = value;
     }
 
     public String getTestExecutionName() {
-        return testExecutionName;
+        return StringUtils.trimToEmpty(testExecutionName);
     }
 
-    public void setTestExecutionName(final String value) {
+    @DataBoundSetter
+    public void setTestExecutionName(@CheckForNull String value) {
         this.testExecutionName = value;
     }
 
     public String getBrowser() {
-        return browser;
+        return StringUtils.trimToEmpty(browser);
     }
 
-    public void setBrowser(final String value) {
+    @DataBoundSetter
+    public void setBrowser(@CheckForNull String value) {
         this.browser = value;
     }
 
     public String getDevice() {
-        return device;
+        return StringUtils.trimToEmpty(device);
     }
 
-    public void setDevice(final String value) {
+    @DataBoundSetter
+    public void setDevice(@CheckForNull String value) {
         this.device = value;
     }
 
     public String getDeviceType() {
-        return deviceType;
+        return StringUtils.trimToEmpty(deviceType);
     }
 
-    public void setDeviceType(final String value) {
+    @DataBoundSetter
+    public void setDeviceType(@CheckForNull String value) {
         this.deviceType = value;
     }
 
     public String getOs() {
-        return os;
+        return StringUtils.trimToEmpty(os);
     }
 
-    public void setOs(final String value) {
+    @DataBoundSetter
+    public void setOs(@CheckForNull String value) {
         this.os = value;
     }
 
     public String getOsVersion() {
-        return osVersion;
+        return StringUtils.trimToEmpty(osVersion);
     }
 
-    public void setOsVersion(final String value) {
+    @DataBoundSetter
+    public void setOsVersion(@CheckForNull String value) {
         this.osVersion = value;
     }
 

--- a/src/test/java/io/jenkins/plugins/autify/AutifyCliStub.java
+++ b/src/test/java/io/jenkins/plugins/autify/AutifyCliStub.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.autify;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+
+public class AutifyCliStub extends AutifyCli {
+
+    public AutifyCliStub(FilePath workspace, Launcher launcher, TaskListener listener) {
+        super(workspace, launcher, listener);
+        this.autifyPath = "echo";
+    }
+
+    public int install() {
+        logger.println("Executing script from " + INSTALL_SCRIPT_URL);
+        return 0;
+    }
+
+    public static class Factory extends AutifyCli.Factory {
+        public AutifyCli get(FilePath workspace, Launcher launcher, TaskListener listener) {
+            return new AutifyCliStub(workspace, launcher, listener);
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/autify/AutifyCliTest.java
+++ b/src/test/java/io/jenkins/plugins/autify/AutifyCliTest.java
@@ -1,5 +1,0 @@
-package io.jenkins.plugins.autify;
-
-public class AutifyCliTest {
-  
-}

--- a/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
@@ -3,7 +3,11 @@ package io.jenkins.plugins.autify;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Label;
+import hudson.util.ArgumentListBuilder;
 import hudson.util.Secret;
+import io.jenkins.plugins.autify.model.UrlReplacement;
+
+import java.util.Arrays;
 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
@@ -27,13 +31,27 @@ public class AutifyWebBuilderTest {
     final String autifyUrl = "https://app.autify.com/projects/743/scenarios/91437";
     final String credentialsId = "autifyWeb";
     final String accessToken = "token";
-
+    final String timeout = "10";
+    final UrlReplacement urlReplacement = new UrlReplacement("https://foo.com", "https://bar.com");
+    final String stub = "foo";
+    final String webTestRunFullCommand = new ArgumentListBuilder("web", "test", "run")
+        .add(autifyUrl)
+        .add("--wait")
+        .add("--timeout", timeout)
+        .add("--url-replacements", urlReplacement.toCliString())
+        .add("--name", stub)
+        .add("--browser", stub)
+        .add("--device", stub)
+        .add("--device-type", stub)
+        .add("--os", stub)
+        .add("--os-version", stub)
+        .toString() + "\n";
 
     @Before
     public void setup() {
         StringCredentials credentials = new StringCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "", Secret.fromString(accessToken));
         SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
-        AutifyWebBuilder.setAutifyCliFactory(new AutifyCliWithProxy.Factory());
+        AutifyWebBuilder.setAutifyCliFactory(new AutifyCliStub.Factory());
     }
 
     @After
@@ -50,42 +68,82 @@ public class AutifyWebBuilderTest {
     }
 
     @Test
-    public void testConfigRoundtripWait() throws Exception {
+    public void testConfigRoundtripFull() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
         AutifyWebBuilder builder = new AutifyWebBuilder(credentialsId, autifyUrl);
         builder.setWait(true);
+        builder.setTimeout(timeout);
+        builder.setUrlReplacements(Arrays.asList(urlReplacement));
+        builder.setTestExecutionName(stub);
+        builder.setBrowser(stub);
+        builder.setDevice(stub);
+        builder.setDeviceType(stub);
+        builder.setOs(stub);
+        builder.setOsVersion(stub);
         project.getBuildersList().add(builder);
         project = jenkins.configRoundtrip(project);
 
         AutifyWebBuilder lhs = new AutifyWebBuilder(credentialsId, autifyUrl);
         lhs.setWait(true);
+        lhs.setTimeout(timeout);
+        lhs.setUrlReplacements(Arrays.asList(urlReplacement));
+        lhs.setTestExecutionName(stub);
+        lhs.setBrowser(stub);
+        lhs.setDevice(stub);
+        lhs.setDeviceType(stub);
+        lhs.setOs(stub);
+        lhs.setOsVersion(stub);
         jenkins.assertEqualDataBoundBeans(lhs, project.getBuildersList().get(0));
     }
 
     @Test
     public void testBuild() throws Exception {
+        AutifyWebBuilder.setAutifyCliFactory(new AutifyCliWithProxy.Factory());
         FreeStyleProject project = jenkins.createFreeStyleProject();
         AutifyWebBuilder builder = new AutifyWebBuilder(credentialsId, autifyUrl);
         project.getBuildersList().add(builder);
 
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(autifyUrl, build);
+        jenkins.assertLogContains("Executing script from " + AutifyCli.INSTALL_SCRIPT_URL, build);
+        jenkins.assertLogContains("web test run " + autifyUrl + "\n", build);
     }
 
     @Test
     public void testBuildWait() throws Exception {
+        AutifyWebBuilder.setAutifyCliFactory(new AutifyCliWithProxy.Factory());
         FreeStyleProject project = jenkins.createFreeStyleProject();
         AutifyWebBuilder builder = new AutifyWebBuilder(credentialsId, autifyUrl);
         builder.setWait(true);
         project.getBuildersList().add(builder);
 
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-        jenkins.assertLogContains(autifyUrl, build);
-        jenkins.assertLogContains("wait", build);
+        jenkins.assertLogContains("Executing script from " + AutifyCli.INSTALL_SCRIPT_URL, build);
+        jenkins.assertLogContains("web test run " + autifyUrl + " --wait\n", build);
+    }
+
+    @Test
+    public void testBuildAllFields() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        AutifyWebBuilder builder = new AutifyWebBuilder(credentialsId, autifyUrl);
+        builder.setWait(true);
+        builder.setTimeout(timeout);
+        builder.setUrlReplacements(Arrays.asList(urlReplacement));
+        builder.setTestExecutionName(stub);
+        builder.setBrowser(stub);
+        builder.setDevice(stub);
+        builder.setDeviceType(stub);
+        builder.setOs(stub);
+        builder.setOsVersion(stub);
+        project.getBuildersList().add(builder);
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        jenkins.assertLogContains("Executing script from " + AutifyCli.INSTALL_SCRIPT_URL, build);
+        jenkins.assertLogContains(webTestRunFullCommand, build);
     }
 
     @Test
     public void testScriptedPipeline() throws Exception {
+        AutifyWebBuilder.setAutifyCliFactory(new AutifyCliWithProxy.Factory());
         String agentLabel = "my-agent";
         jenkins.createOnlineSlave(Label.get(agentLabel));
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
@@ -95,8 +153,34 @@ public class AutifyWebBuilderTest {
                 + "}";
         job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
         WorkflowRun completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
-        String expectedString = autifyUrl;
-        jenkins.assertLogContains(expectedString, completedBuild);
+        jenkins.assertLogContains("Executing script from " + AutifyCli.INSTALL_SCRIPT_URL, completedBuild);
+        jenkins.assertLogContains("web test run " + autifyUrl + "\n", completedBuild);
+    }
+
+    @Test
+    public void testScriptedPipelineAllField() throws Exception {
+        String agentLabel = "my-agent";
+        jenkins.createOnlineSlave(Label.get(agentLabel));
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test-scripted-pipeline");
+        String pipelineScript
+                = "node {\n"
+                + "  autifyWeb "
+                + "credentialsId: '" + credentialsId + "', "
+                + "autifyUrl: '"+ autifyUrl +"', "
+                + "wait: true, "
+                + "timeout: '"+ timeout +"', "
+                + "urlReplacements: [[patternUrl: '"+ urlReplacement.getPatternUrl() + "', replacementUrl: '"+ urlReplacement.getReplacementUrl() +"']], "
+                + "testExecutionName: '"+ stub +"', "
+                + "browser: '"+ stub +"', "
+                + "device: '"+ stub +"', "
+                + "deviceType: '"+ stub +"', "
+                + "os: '"+ stub +"', "
+                + "osVersion: '"+ stub +"'\n"
+                + "}";
+        job.setDefinition(new CpsFlowDefinition(pipelineScript, true));
+        WorkflowRun completedBuild = jenkins.assertBuildStatusSuccess(job.scheduleBuild2(0));
+        jenkins.assertLogContains("Executing script from " + AutifyCli.INSTALL_SCRIPT_URL, completedBuild);
+        jenkins.assertLogContains(webTestRunFullCommand, completedBuild);
     }
 
 }


### PR DESCRIPTION
Since only the fields annotated with `@DataBoundSetter` can be used in Pipeline,
we need to change all nullable `String` fields to non-null.

Also, this commit improves unit tests by introducing `AutifyCliStub`.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
