### PR TITLE
Fix XDG overrides

### DIFF
--- a/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
+++ b/src/main/java/io/jenkins/plugins/autify/AutifyCli.java
@@ -122,7 +122,9 @@ public class AutifyCli {
         Map<String, String> envs = new HashMap<String, String>();
         envs.put("AUTIFY_WEB_ACCESS_TOKEN", webAccessToken);
         envs.put("AUTIFY_MOBILE_ACCESS_TOKEN", mobileAccessToken);
-        envs.put("XDG_DATA_HOME", workspace + "/.config");
+        envs.put("XDG_CACHE_HOME", workspace + "/.cache");
+        envs.put("XDG_CONFIG_HOME", workspace + "/.config");
+        envs.put("XDG_DATA_HOME", workspace + "/.data");
         return envs;
     }
 


### PR DESCRIPTION
Previously, XDG_DATA_HOME points `.cache` which doesn't make sense.
This commits fix it to `.data` and adds two more overrides to restrict
all directories under the workspace.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

Close #15 