### PR TITLE
Remove windows build on Jenkins CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,24 +3,11 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 
-/*
-  Windows agents on Jenkins CI don't have Git Bash installed and they have MinGit only:
-  https://github.com/jenkins-infra/packer-images/blob/088eb6eb7f7b37e037a14f8221ed555778559273/provisioning/windows-provision.ps1#L148-L162
-  Therefore, we need to install it on-demand here.
-  Thankfully, since C:\tools\git which is the default install directory of `choco install git.portable`
-  are already included in PATH (actually some of subdriectories), we don't have to worry about PATH modification.
-*/
-infra.ensureInNode('docker-windows') {
-  stage('Install Git for Bash') {
-    bat 'choco install git.portable -v -d -y -f'
-    bat 'bash.exe --version'
-  }
-}
-
 buildPlugin(
   configurations: [
     [ platform: 'linux', jdk: '11' ],
     [ platform: 'linux', jdk: '17' ],
-    [ platform: 'docker-windows', jdk: '11' ],
+    // Windows agent doesn't have bash...
+    // [ platform: 'docker-windows', jdk: '11' ],
   ]
 )


### PR DESCRIPTION
Due to the limitation of the pipeline library, it is impossible to setup bash environment for windows agents.

Since we run windows tests by GitHub Actions, we can skip this now.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
