### PR TITLE
Use latest Jenkins for integration test

### DIFF
--- a/integration-test/integration-test.bash
+++ b/integration-test/integration-test.bash
@@ -13,7 +13,9 @@ export AUTIFY_TEST_WAIT_INTERVAL_SECOND=0
 export AUTIFY_CONNECT_CLIENT_MODE=fake
 
 JENKINS_PLUGINS_DIR="$JENKINS_HOME/plugins"
-JENKINS_WAR_URL="https://get.jenkins.io/war-stable/2.361.1/jenkins.war"
+# The latest version can be found here: https://www.jenkins.io/download/
+JENKINS_WAR_URL="https://get.jenkins.io/war/2.373/jenkins.war"
+# The latest version can be found here: https://github.com/jenkinsci/plugin-installation-manager-tool/releases
 JENKINS_PLUGIN_CLI_JAR_URL="https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.9/jenkins-plugin-manager-2.12.9.jar"
 
 JENKINS_PID=


### PR DESCRIPTION
It might be better to test against the latest instead of LTS
because the latest can be changed dramatically comparing with LTS.

We might add another integration test for LTS later.

---

This change is not compatible with LTS https://github.com/jenkinsci/cloudbees-folder-plugin/pull/264 so that our tests start failing like https://github.com/jenkinsci/autify-plugin/actions/runs/3212345732/jobs/5251131458#step:4:1522