### PR TITLE
Fix the path of WAR file

### DIFF
--- a/integration-test/integration-test.bash
+++ b/integration-test/integration-test.bash
@@ -35,7 +35,7 @@ function exit-handler() {
 trap exit-handler EXIT
 
 function jenkins-plugin-cli() {
-  java -jar "$TARGET_TMP_DIR/jenkins-plugin-manager.jar" --verbose --war jenkins.war --plugin-download-directory "$JENKINS_PLUGINS_DIR" "$@"
+  java -jar "$TARGET_TMP_DIR/jenkins-plugin-manager.jar" --verbose --war "$TARGET_TMP_DIR/jenkins.war" --plugin-download-directory "$JENKINS_PLUGINS_DIR" "$@"
 }
 
 function jenkins-cli() {


### PR DESCRIPTION
The path is wrong so that the latest integration test failure was caused.

```
War not found, installing all plugins: jenkins.war
```
https://github.com/jenkinsci/autify-plugin/actions/runs/3223310041/jobs/5273251259#step:4:195