### PR TITLE
Support space delimiter for URL replacements option

### DIFF
--- a/src/main/java/io/jenkins/plugins/autify/model/UrlReplacement.java
+++ b/src/main/java/io/jenkins/plugins/autify/model/UrlReplacement.java
@@ -11,6 +11,8 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import io.jenkins.plugins.autify.Messages;
 
+import java.lang.module.ModuleDescriptor.Version;
+
 public class UrlReplacement extends AbstractDescribableImpl<UrlReplacement> {
 
     private final String patternUrl;
@@ -30,9 +32,13 @@ public class UrlReplacement extends AbstractDescribableImpl<UrlReplacement> {
         return replacementUrl;
     }
 
-    public String toCliString() {
+    public String toCliString(Version version) {
         if (patternUrl == null || replacementUrl == null) return null;
-        else return patternUrl + "=" + replacementUrl;
+        else if (Version.parse("0.29.0").compareTo((version)) <= 0) {
+            return patternUrl + " " + replacementUrl;
+        } else {
+            return patternUrl + "=" + replacementUrl;
+        }
     }
 
     @Extension

--- a/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
@@ -1,17 +1,12 @@
 package io.jenkins.plugins.autify;
 
-import hudson.model.FreeStyleBuild;
-import hudson.model.FreeStyleProject;
-import hudson.model.Label;
-import hudson.util.ArgumentListBuilder;
-import hudson.util.Secret;
-import io.jenkins.plugins.autify.model.UrlReplacement;
-
 import java.io.File;
 import java.io.IOException;
+import java.lang.module.ModuleDescriptor.Version;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -24,6 +19,13 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Label;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.Secret;
+import io.jenkins.plugins.autify.model.UrlReplacement;
 
 public class AutifyWebBuilderTest {
 
@@ -38,11 +40,11 @@ public class AutifyWebBuilderTest {
     final String timeout = "10";
     final UrlReplacement urlReplacement = new UrlReplacement("https://foo.com", "https://bar.com");
     final String stub = "foo";
-    final String webTestRunFullCommand = new ArgumentListBuilder("web", "test", "run")
+    final String baseWebTestRunFullCommand = new ArgumentListBuilder("web", "test", "run")
             .add(autifyUrl)
             .add("--wait")
             .add("--timeout", timeout)
-            .add("--url-replacements", urlReplacement.toCliString())
+            .add("--url-replacements", urlReplacement.toCliString(Version.parse("0.29.0")))
             .add("--name", stub)
             .add("--browser", stub)
             .add("--device", stub)
@@ -53,6 +55,8 @@ public class AutifyWebBuilderTest {
             .add("--autify-connect-client")
             .add("--autify-connect-client-extra-arguments", stub)
             .toString() + "\n";
+    // On Windows surrounded with single quotes
+    final String webTestRunFullCommand = SystemUtils.IS_OS_WINDOWS ? baseWebTestRunFullCommand.replaceAll("\"", "'") : baseWebTestRunFullCommand;
 
     AutifyWebBuilder builder;
 

--- a/src/test/java/io/jenkins/plugins/autify/UrlReplacementTest.java
+++ b/src/test/java/io/jenkins/plugins/autify/UrlReplacementTest.java
@@ -1,0 +1,23 @@
+package io.jenkins.plugins.autify;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.module.ModuleDescriptor.Version;
+
+import org.junit.Test;
+
+import io.jenkins.plugins.autify.model.UrlReplacement;
+
+public class UrlReplacementTest {
+    @Test
+    public void testSpaceDelimiter() throws Exception {
+        UrlReplacement urlReplacement = new UrlReplacement("https://example.com", "https://example.net");
+        assertEquals("https://example.com https://example.net", urlReplacement.toCliString(Version.parse("0.29.0")));
+    }
+
+    @Test
+    public void testEqualDelimiter() throws Exception {
+        UrlReplacement urlReplacement = new UrlReplacement("https://example.com", "https://example.net");
+        assertEquals("https://example.com=https://example.net", urlReplacement.toCliString(Version.parse("0.28.0")));
+    }
+}

--- a/src/test/resources/install-stub.bash
+++ b/src/test/resources/install-stub.bash
@@ -4,13 +4,17 @@ mkdir -p "$DIR/autify/bin"
 
 cat << EOS > "$DIR/autify/bin/autify"
 #!/bin/bash
-echo "\$@"
+if [[ "\$@" == "--version" ]]; then
+  echo "@autifyhq/autify-cli/0.29.0 linux-x64 node-v18.15.0"
+else
+  echo "\$@"
+fi
 EOS
 chmod +x "$DIR/autify/bin/autify"
 
 cat << EOS > "$DIR/autify/bin/autify.cmd"
 @ECHO OFF
-ECHO %*
+IF %1==--version (ECHO @autifyhq/autify-cli/0.29.0 win32-x64 node-v18.15.0) ELSE ECHO %*
 EOS
 
 echo "$DIR/autify/bin" >> "$DIR/autify/path"


### PR DESCRIPTION
Autify CLI now uses space as a delimiter for `--url-replacements` option.

https://github.com/autifyhq/autify-cli/pull/389

This PR is to follow the change.

## Manual test

I setup Jenkins on my Windows machine and installed plugin (.hpi) manually

https://ci.jenkins.io/job/Plugins/job/autify-plugin/view/change-requests/job/PR-68/

### Old Autify CLI (0.28.0)

--url-replacements option uses `=` delimiter

![image](https://user-images.githubusercontent.com/1796864/231088899-344673d4-01f8-4b64-b3ab-a72fea5fb793.png)

### Old Autify CLI but supports space delimiter (0.29.0)

--url-replacements option uses space delimiter

![image](https://user-images.githubusercontent.com/1796864/231096089-c8b17e63-9cdd-4f63-b7dd-21ea1ce0898a.png)

### The latest Autify CLI (0.30.0)

--url-replacements option uses space delimiter

![image](https://user-images.githubusercontent.com/1796864/231088717-ee0fee1e-aaec-49fc-b8e3-3d3c99347fae.png)

