### PR TITLE
Support space delimiter for URL replacements option (take 2)

### DIFF
--- a/src/main/java/io/jenkins/plugins/autify/model/UrlReplacement.java
+++ b/src/main/java/io/jenkins/plugins/autify/model/UrlReplacement.java
@@ -32,7 +32,7 @@ public class UrlReplacement extends AbstractDescribableImpl<UrlReplacement> {
 
     public String toCliString() {
         if (patternUrl == null || replacementUrl == null) return null;
-        else return patternUrl + "=" + replacementUrl;
+        else return patternUrl + " " + replacementUrl;
     }
 
     @Extension

--- a/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
+++ b/src/test/java/io/jenkins/plugins/autify/AutifyWebBuilderTest.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.Arrays;
 
+import org.apache.commons.lang.SystemUtils;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -38,7 +39,7 @@ public class AutifyWebBuilderTest {
     final String timeout = "10";
     final UrlReplacement urlReplacement = new UrlReplacement("https://foo.com", "https://bar.com");
     final String stub = "foo";
-    final String webTestRunFullCommand = new ArgumentListBuilder("web", "test", "run")
+    final String baseWebTestRunFullCommand = new ArgumentListBuilder("web", "test", "run")
             .add(autifyUrl)
             .add("--wait")
             .add("--timeout", timeout)
@@ -53,6 +54,8 @@ public class AutifyWebBuilderTest {
             .add("--autify-connect-client")
             .add("--autify-connect-client-extra-arguments", stub)
             .toString() + "\n";
+    // On Windows surrounded with single quotes
+    final String webTestRunFullCommand = SystemUtils.IS_OS_WINDOWS ? baseWebTestRunFullCommand.replaceAll("\"", "'") : baseWebTestRunFullCommand;
 
     AutifyWebBuilder builder;
 


### PR DESCRIPTION
Autify CLI now uses space as a delimiter for `--url-replacements` option.

https://github.com/autifyhq/autify-cli/pull/389

This PR is to follow the change.

## Manual test

I setup Jenkins on my Windows machine and installed plugin (.hpi) manually

https://ci.jenkins.io/job/Plugins/job/autify-plugin/view/change-requests/job/PR-68/

--url-replacements option uses space delimiter

![image](https://user-images.githubusercontent.com/1796864/231088717-ee0fee1e-aaec-49fc-b8e3-3d3c99347fae.png)

