### PR TITLE
fix: updated Jenkins WAR Url

### DIFF
--- a/integration-test/integration-test.bash
+++ b/integration-test/integration-test.bash
@@ -14,7 +14,7 @@ export AUTIFY_CONNECT_CLIENT_MODE=fake
 
 JENKINS_PLUGINS_DIR="$JENKINS_HOME/plugins"
 # The latest version can be found here: https://www.jenkins.io/download/
-JENKINS_WAR_URL="https://get.jenkins.io/war/2.373/jenkins.war"
+JENKINS_WAR_URL="https://get.jenkins.io/war/2.419/jenkins.war"
 # The latest version can be found here: https://github.com/jenkinsci/plugin-installation-manager-tool/releases
 JENKINS_PLUGIN_CLI_JAR_URL="https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.9/jenkins-plugin-manager-2.12.9.jar"
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Changed `JENKINS_WAR_URL` to fix the error `cloudbees-folder (6.815.v0dd5a_cb_40e0e) requires a greater version of Jenkins (2.375.1) than 2.373`
ref: https://github.com/jenkinsci/autify-plugin/actions/runs/7777727934/job/21206397858

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
