### PR TITLE
Bump jenkins version to fix the CI failure

### DIFF
--- a/integration-test/integration-test.bash
+++ b/integration-test/integration-test.bash
@@ -14,7 +14,7 @@ export AUTIFY_CONNECT_CLIENT_MODE=fake
 
 JENKINS_PLUGINS_DIR="$JENKINS_HOME/plugins"
 # The latest version can be found here: https://www.jenkins.io/download/
-JENKINS_WAR_URL="https://get.jenkins.io/war/2.419/jenkins.war"
+JENKINS_WAR_URL="https://get.jenkins.io/war-stable/2.426.3/jenkins.war"
 # The latest version can be found here: https://github.com/jenkinsci/plugin-installation-manager-tool/releases
 JENKINS_PLUGIN_CLI_JAR_URL="https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.9/jenkins-plugin-manager-2.12.9.jar"
 


### PR DESCRIPTION
To fix CI failure on main branch, something like this:

```
io.jenkins.tools.pluginmanager.impl.AggregatePluginPrerequisitesNotMetException: Multiple plugin prerequisites not met:

credentials (1380.va_435002fa_924) requires a greater version of Jenkins (2.426.3) than 2.419,
```

https://github.com/jenkinsci/autify-plugin/actions/runs/12407918109/job/34638701553?pr=148